### PR TITLE
Clear result panel before each SQL execution

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,6 +58,8 @@ runBtn.onclick = () => {
   runBtn.disabled = true;
   statusSpan.textContent = "Выполняю...";
   errorDiv.textContent = "";
+  // очищаем предыдущий результат, чтобы не вводить пользователя в заблуждение при ошибке
+  resultDiv.innerHTML = "";
   try {
     const query = sqlBox.value;
     const res = db.exec(query); // массив result-set'ов


### PR DESCRIPTION
## Summary
- Clear previous query results before running new SQL to avoid stale data after errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a18799ed40832e8ec057aeffc76e09