### PR TITLE
Limit SQL result rows and collapse schema tables

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -21,7 +21,8 @@ export function executeQuery(query) {
       return { ok: true, columns: [], rows: [] };
     }
     const { columns, values } = res[0];
-    return { ok: true, columns, rows: values };
+    // Ограничиваем вывод результата максимум 5 строками без изменения исходного запроса
+    return { ok: true, columns, rows: values.slice(0, 5) };
   } catch (e) {
     return { ok: false, error: String(e) };
   }

--- a/src/ui/schema.js
+++ b/src/ui/schema.js
@@ -1,10 +1,12 @@
+// Показываем схемы таблиц как раскрывающиеся списки,
+// чтобы занимать меньше места и явно указывать, что список можно раскрыть
 export function renderSchema(container, tables) {
   container.innerHTML = tables
     .map(
       (t) =>
-        `<div class="table"><strong>${t.name}</strong><ul>${t.columns
+        `<details class="table"><summary>${t.name}</summary><ul>${t.columns
           .map((c) => `<li>${c}</li>`)
-          .join("")}</ul></div>`
+          .join("")}</ul></details>`
     )
     .join("");
 }


### PR DESCRIPTION
## Summary
- Limit SQL query results to five displayed rows without changing original query
- Render table schemas as collapsible lists with a dropdown arrow for each table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b54f4bba18832ea2fae985766353e3