### PR TITLE
Revamp UI with desktop-like windows and iMessage chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,32 +4,221 @@
     <meta charset="UTF-8" />
     <title>SQL Detective</title>
     <style>
-      body, html { margin:0; padding:0; height:100%; font-family:sans-serif; }
-      .layout { display:grid; grid-template-columns:1fr 2fr 1fr; height:100vh; }
-      .schema, .chat, .editor-area { padding:8px; overflow:auto; }
-      .schema { border-right:1px solid #ccc; }
-      .chat { border-left:1px solid #ccc; display:flex; flex-direction:column; }
-      .chat .messages { flex:1; overflow:auto; }
-      .chat .outgoing { display:flex; margin-top:8px; }
-      .chat .outgoing input { flex:1; }
-      .editor-area { display:flex; flex-direction:column; }
-      .editor-area textarea { flex:1; }
-      .editor-area button { margin-top:4px; align-self:flex-start; }
-      .result { margin-top:8px; overflow:auto; border-top:1px solid #ccc; padding-top:8px; }
-      table { border-collapse: collapse; }
-      th, td { border:1px solid #ccc; padding:2px 4px; }
-      .error { color: red; white-space: pre-wrap; }
-      .empty { color: #666; }
+      body, html {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        font-family: sans-serif;
+        background: #1e1e1e;
+      }
+
+      .desktop {
+        display: grid;
+        grid-template-columns: 1fr 2fr 1fr;
+        gap: 20px;
+        padding: 20px;
+        height: 100vh;
+        box-sizing: border-box;
+      }
+
+      .window {
+        display: flex;
+        flex-direction: column;
+        background: #f7f7f7;
+        border: 1px solid #444;
+        border-radius: 6px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+        overflow: hidden;
+      }
+
+      .title-bar {
+        background: #e0e0e0;
+        padding: 8px;
+        font-weight: bold;
+        border-bottom: 1px solid #bbb;
+      }
+
+      /* Schema window */
+      .schema-content {
+        padding: 8px;
+        overflow: auto;
+        flex: 1;
+      }
+
+      .schema-content details {
+        margin-bottom: 8px;
+      }
+
+      .schema-content summary {
+        cursor: pointer;
+        list-style: none;
+        background: #e0e0e0;
+        border: 1px solid #888;
+        border-radius: 4px;
+        padding: 4px 8px;
+        display: inline-block;
+      }
+
+      .schema-content summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .schema-content ul {
+        margin: 4px 0 0 12px;
+      }
+
+      /* Editor window */
+      .editor {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        background: #000;
+        color: #0f0;
+        padding: 8px;
+      }
+
+      .editor textarea {
+        flex: 1;
+        background: #000;
+        color: #0f0;
+        border: none;
+        resize: none;
+        font-family: monospace;
+      }
+
+      .editor button {
+        align-self: flex-start;
+        margin-top: 4px;
+        background: #222;
+        color: #0f0;
+        border: 1px solid #0f0;
+        border-radius: 4px;
+        padding: 4px 8px;
+        cursor: pointer;
+      }
+
+      .result {
+        flex: 1;
+        overflow: auto;
+        padding: 8px;
+        border-top: 1px solid #ccc;
+        background: #fff;
+      }
+
+      .result table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+
+      .result th,
+      .result td {
+        border: 1px solid #ccc;
+        padding: 4px 8px;
+      }
+
+      .error {
+        color: red;
+        white-space: pre-wrap;
+      }
+
+      .empty {
+        color: #666;
+      }
+
+      /* Chat window */
+      .chat {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+      }
+
+      .chat .messages {
+        flex: 1;
+        overflow: auto;
+        padding: 8px;
+      }
+
+      .chat .msg {
+        margin-bottom: 8px;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .chat .msg.in {
+        align-items: flex-start;
+      }
+
+      .chat .msg.out {
+        align-items: flex-end;
+      }
+
+      .chat .msg .sender {
+        font-size: 12px;
+        color: #555;
+        margin-bottom: 2px;
+      }
+
+      .chat .msg .bubble {
+        max-width: 80%;
+        padding: 6px 10px;
+        border-radius: 16px;
+      }
+
+      .chat .msg.in .bubble {
+        background: #e5e5ea;
+        color: #000;
+      }
+
+      .chat .msg.out .bubble {
+        background: #0b93f6;
+        color: #fff;
+      }
+
+      .chat .outgoing {
+        display: flex;
+        padding: 8px;
+        gap: 8px;
+      }
+
+      .chat .outgoing input {
+        flex: 1;
+        border: 1px solid #ccc;
+        border-radius: 16px;
+        padding: 6px 10px;
+      }
+
+      .chat .outgoing button {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        border: none;
+        background: #0b93f6;
+        color: #fff;
+        font-size: 18px;
+        cursor: pointer;
+      }
+
+      .chat .outgoing button:disabled {
+        background: #9dc9f0;
+        cursor: default;
+      }
     </style>
   </head>
   <body>
-    <div class="layout">
-      <div id="schema" class="schema"></div>
-      <div class="editor-area">
-        <div id="editor"></div>
+    <div class="desktop">
+      <div class="window schema-window">
+        <div class="title-bar">Schema Master</div>
+        <div id="schema" class="schema-content"></div>
+      </div>
+      <div class="window editor-window">
+        <div class="title-bar">SQL Editor</div>
+        <div id="editor" class="editor"></div>
         <div id="result" class="result"></div>
       </div>
-      <div id="chat" class="chat"></div>
+      <div class="window chat-window">
+        <div class="title-bar">Messenger</div>
+        <div id="chat" class="chat"></div>
+      </div>
     </div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -4,12 +4,19 @@ export function renderChat(container, state) {
   container.innerHTML = `
     <div class="messages">
       ${state.messages
-        .map((m) => `<div class="msg"><strong>${m.from}:</strong> ${m.text}</div>`)
+        .map(
+          (m) => `
+        <div class="msg ${m.from === 'Вы' ? 'out' : 'in'}">
+          ${m.from === 'Вы' ? '' : `<div class="sender">${m.from}</div>`}
+          <div class="bubble">${m.text}</div>
+        </div>
+      `
+        )
         .join("")}
     </div>
     <div class="outgoing">
       <input type="text" disabled />
-      <button disabled>Send</button>
+      <button disabled>&uarr;</button>
     </div>
   `;
   const btn = container.querySelector("button");


### PR DESCRIPTION
## Summary
- Redesign page to mimic a desktop with windowed sections for schema, SQL editor, and chat
- Style SQL editor with black background and green text and place result table underneath
- Rework chat into iMessage-style bubbles with arrow send button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b58072539c832e983abca528bedd33