### PR TITLE
Improve sizing across Detective SQL UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,12 @@
         display: inline-block;
       }
 
+      .schema-content summary::after {
+        content: "\25BC";
+        font-size: 10px;
+        margin-left: 6px;
+      }
+
       .schema-content summary::-webkit-details-marker {
         display: none;
       }
@@ -84,6 +90,7 @@
         border: none;
         resize: none;
         font-family: monospace;
+        font-size: 48px;
       }
 
       .editor button {
@@ -93,7 +100,8 @@
         color: #0f0;
         border: 1px solid #0f0;
         border-radius: 4px;
-        padding: 4px 8px;
+        padding: 8px 16px;
+        font-size: 32px;
         cursor: pointer;
       }
 
@@ -184,7 +192,8 @@
         flex: 1;
         border: 1px solid #ccc;
         border-radius: 16px;
-        padding: 6px 10px;
+        padding: 12px 20px;
+        font-size: 32px;
       }
 
       .chat .outgoing button {
@@ -209,10 +218,15 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background: rgba(0, 0, 0, 0.7);
+        background: rgba(0, 0, 0, 0.85);
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
+        text-align: center;
+        color: #fff;
+        gap: 20px;
+        padding: 20px;
         z-index: 1000;
       }
 
@@ -225,14 +239,15 @@
         color: #fff;
         border: none;
         border-radius: 8px;
-        padding: 12px 24px;
-        font-size: 18px;
+        padding: 20px 40px;
+        font-size: 24px;
         cursor: pointer;
       }
     </style>
   </head>
   <body>
     <div id="start-screen" class="start-screen">
+      <p>Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти спать, вам начинают приходить тревожные сообщения</p>
       <button id="start-button">Начать</button>
     </div>
     <div class="desktop">


### PR DESCRIPTION
## Summary
- darken splash screen overlay and enlarge the start button
- triple SQL editor font size and double Run button size
- indicate expandable schema tables with a downward arrow
- enlarge messenger input field and its text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b69498213c832ebfd5d5b7fdd5385d