### PR TITLE
Enable scrolling in Messenger window

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,11 +138,12 @@
         display: flex;
         flex-direction: column;
         flex: 1;
+        min-height: 0;
       }
 
       .chat .messages {
         flex: 1;
-        overflow: auto;
+        overflow-y: auto;
         padding: 8px;
       }
 


### PR DESCRIPTION
## Summary
- allow chat messages area to scroll by adding min-height and overflow styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b745721b34832eb55ed8c322b8ab9f