### PR TITLE
Fix send button alignment in chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,10 +197,12 @@
         display: flex;
         padding: 8px;
         gap: 8px;
+        box-sizing: border-box;
       }
 
       .chat .outgoing input {
         flex: 1;
+        min-width: 0;
         border: 1px solid #ccc;
         border-radius: 16px;
         padding: 12px 20px;


### PR DESCRIPTION
## Summary
- ensure chat send button stays within messenger by sizing container and allowing input to shrink

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b74692e6e0832ebe0afb981e40f99f