### PR TITLE
Tweak UI sizes, keep chat scrolled, delay detective replies

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         border: none;
         resize: none;
         font-family: monospace;
-        font-size: 32px;
+        font-size: 21px;
       }
 
       .editor button {
@@ -100,8 +100,8 @@
         color: #0f0;
         border: 1px solid #0f0;
         border-radius: 4px;
-        padding: 8px 16px;
-        font-size: 32px;
+        padding: 5px 10px;
+        font-size: 21px;
         cursor: pointer;
       }
 
@@ -205,8 +205,8 @@
         min-width: 0;
         border: 1px solid #ccc;
         border-radius: 16px;
-        padding: 12px 20px;
-        font-size: 21px;
+        padding: 8px 13px;
+        font-size: 14px;
       }
 
       .chat .outgoing button {

--- a/src/main.js
+++ b/src/main.js
@@ -54,7 +54,7 @@ onSend((text) => {
     setTimeout(() => {
       addMessage(m.from, m.text);
       renderChat(chatEl, state);
-    }, i * 5000);
+    }, (i + 1) * 5000);
   });
   state.currentStep += 1;
 });

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -30,6 +30,10 @@ export function renderChat(container, state) {
   const btn = container.querySelector("button");
   const input = container.querySelector("input");
   btn.addEventListener("click", () => sendHandler(input.value));
+  const messages = container.querySelector('.messages');
+  if (messages) {
+    messages.scrollTop = messages.scrollHeight;
+  }
 }
 
 export function setOutgoingMessage(text) {


### PR DESCRIPTION
## Summary
- Shrink Messenger input font and SQL editor text/button by 1.5x
- Keep chat view anchored to bottom when new messages arrive
- Wait 5 seconds before detective messages in new cycles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b749ea98c0832ea8b2d8c8b3d7f59b