### PR TITLE
Adjust chat font to Apple system Cyrillic

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,12 +181,16 @@
         flex: 1;
         overflow-y: auto;
         padding: 8px;
+        font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
+          "Segoe UI", "Helvetica Neue", Arial, sans-serif;
       }
 
       .chat .msg {
         margin-bottom: 8px;
         display: flex;
         flex-direction: column;
+        font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
+          "Segoe UI", "Helvetica Neue", Arial, sans-serif;
       }
 
       .chat .msg.in {


### PR DESCRIPTION
## Summary
- switch the chat message area to Apple system Cyrillic fonts (SF Pro) for better readability on supporting devices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda628aafc832eac645c705a83aa6c