### PR TITLE
Restore classic monitor frame without stand

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,20 +4,121 @@
     <meta charset="UTF-8" />
     <title>SQL Detective</title>
     <style>
-      body, html {
+      html,
+      body {
         margin: 0;
         padding: 0;
         height: 100%;
         font-family: sans-serif;
-        background: #1e1e1e;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at top, #2b313a 0%, #14171d 60%, #090b0f 100%);
+      }
+
+      .workspace {
+        width: 100%;
+        max-width: 1400px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 40px 24px 80px;
+        box-sizing: border-box;
+      }
+
+      .monitor {
+        width: 100%;
+        max-width: 1180px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0;
+      }
+
+      .monitor-surface {
+        width: 100%;
+        background: linear-gradient(180deg, #2d333f 0%, #141820 58%, #08090f 100%);
+        border-radius: 34px 34px 24px 24px;
+        padding: 58px 64px 42px;
+        box-sizing: border-box;
+        position: relative;
+        box-shadow: 0 42px 120px rgba(0, 0, 0, 0.65);
+      }
+
+      .monitor-surface::before {
+        content: "";
+        position: absolute;
+        inset: 18px 42px auto;
+        height: 20px;
+        border-radius: 18px;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .monitor-camera {
+        position: absolute;
+        top: 26px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, #4b505a 0%, #181b22 55%, #07090d 100%);
+        box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.08);
+      }
+
+      .monitor-screen {
+        position: relative;
+        width: 100%;
+        height: clamp(440px, 60vh, 720px);
+        padding: 32px;
+        box-sizing: border-box;
+        border-radius: 20px;
+        background: radial-gradient(circle at top, #0b0d14 0%, #040507 65%, #010102 100%);
+        box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.04), inset 0 0 45px rgba(0, 0, 0, 0.7);
+        overflow: hidden;
+        display: flex;
+      }
+
+      .monitor-chin {
+        position: relative;
+        width: 100%;
+        height: clamp(70px, 12vh, 96px);
+        margin-top: -8px;
+        background: linear-gradient(180deg, #f7f8fa 0%, #d5d9e1 52%, #bcc1cb 100%);
+        border-radius: 0 0 34px 34px;
+        border-top: 1px solid rgba(255, 255, 255, 0.7);
+        box-shadow: 0 30px 56px rgba(0, 0, 0, 0.45);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .monitor-chin::before {
+        content: "";
+        position: absolute;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 48%;
+        height: 8px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.5);
+        filter: blur(2px);
+        opacity: 0.65;
       }
 
       .desktop {
+        flex: 1;
         display: grid;
         grid-template-columns: 1fr 2fr 1fr;
         gap: 20px;
         padding: 20px;
-        height: 100vh;
+        height: 100%;
         box-sizing: border-box;
       }
 
@@ -74,7 +175,6 @@
         pointer-events: none;
       }
 
-      /* Schema window */
       .schema-content {
         padding: 8px;
         overflow: auto;
@@ -109,7 +209,6 @@
         margin: 4px 0 0 12px;
       }
 
-      /* Editor window */
       .editor {
         display: flex;
         flex-direction: column;
@@ -169,7 +268,6 @@
         color: #666;
       }
 
-      /* Chat window */
       .chat {
         display: flex;
         flex-direction: column;
@@ -267,12 +365,9 @@
       }
 
       .start-screen {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.85);
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.88);
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -281,7 +376,9 @@
         color: #fff;
         gap: 20px;
         padding: 20px;
-        z-index: 1000;
+        border-radius: 12px;
+        z-index: 10;
+        box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.4);
       }
 
       .start-screen.hidden {
@@ -297,47 +394,87 @@
         font-size: 24px;
         cursor: pointer;
       }
+
+      @media (max-width: 900px) {
+        .monitor-surface {
+          padding: 46px 40px 34px;
+        }
+
+        .monitor-screen {
+          padding: 26px;
+          height: clamp(400px, 60vh, 640px);
+        }
+
+        .desktop {
+          gap: 16px;
+          padding: 16px;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .monitor-screen {
+          padding: 20px;
+        }
+
+        .desktop {
+          grid-template-columns: 1fr;
+          grid-auto-rows: minmax(0, auto);
+        }
+      }
     </style>
   </head>
   <body>
-    <div id="start-screen" class="start-screen">
-      <p id="start-text">Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти спать, вам начинают приходить тревожные сообщения</p>
-      <button id="start-button">Начать</button>
-    </div>
-    <div class="desktop">
-      <div class="window schema-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
+    <div class="workspace">
+      <div class="monitor">
+        <div class="monitor-surface">
+          <div class="monitor-camera"></div>
+          <div class="monitor-screen">
+            <div id="start-screen" class="start-screen">
+              <p id="start-text">
+                Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти
+                спать, вам начинают приходить тревожные сообщения
+              </p>
+              <button id="start-button">Начать</button>
+            </div>
+            <div class="desktop">
+              <div class="window schema-window">
+                <div class="title-bar">
+                  <div class="window-buttons">
+                    <span class="close"></span>
+                    <span class="minimize"></span>
+                    <span class="maximize"></span>
+                  </div>
+                  <span class="title">Schema Master</span>
+                </div>
+                <div id="schema" class="schema-content"></div>
+              </div>
+              <div class="window editor-window">
+                <div class="title-bar">
+                  <div class="window-buttons">
+                    <span class="close"></span>
+                    <span class="minimize"></span>
+                    <span class="maximize"></span>
+                  </div>
+                  <span class="title">SQL Editor</span>
+                </div>
+                <div id="editor" class="editor"></div>
+                <div id="result" class="result"></div>
+              </div>
+              <div class="window chat-window">
+                <div class="title-bar">
+                  <div class="window-buttons">
+                    <span class="close"></span>
+                    <span class="minimize"></span>
+                    <span class="maximize"></span>
+                  </div>
+                  <span class="title">Messenger</span>
+                </div>
+                <div id="chat" class="chat"></div>
+              </div>
+            </div>
           </div>
-          <span class="title">Schema Master</span>
         </div>
-        <div id="schema" class="schema-content"></div>
-      </div>
-      <div class="window editor-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
-          </div>
-          <span class="title">SQL Editor</span>
-        </div>
-        <div id="editor" class="editor"></div>
-        <div id="result" class="result"></div>
-      </div>
-      <div class="window chat-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
-          </div>
-          <span class="title">Messenger</span>
-        </div>
-        <div id="chat" class="chat"></div>
+        <div class="monitor-chin"></div>
       </div>
     </div>
     <script type="module" src="/src/main.js"></script>


### PR DESCRIPTION
## Summary
- restore the darker bezel and screen treatment from the earlier monitor mock so the desktop windows sit on a black display again
- drop the LAPD chin branding and leave the monitor without a stand for the cleaner floating look the user requested

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda97c20e0832eae0de6ac35303d8d