### PR TITLE
Adjust monitor layout for improved readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,17 +21,17 @@
 
       .workspace {
         width: 100%;
-        max-width: 1400px;
+        max-width: 1360px;
         display: flex;
         flex-direction: column;
         align-items: center;
-        padding: 40px 24px 80px;
+        padding: 24px 16px 48px;
         box-sizing: border-box;
       }
 
       .monitor {
-        width: 100%;
-        max-width: 1180px;
+        width: 1080px;
+        max-width: 100%;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -41,18 +41,18 @@
       .monitor-surface {
         width: 100%;
         background: linear-gradient(180deg, #2d333f 0%, #141820 58%, #08090f 100%);
-        border-radius: 34px 34px 24px 24px;
-        padding: 58px 64px 42px;
+        border-radius: 32px 32px 24px 24px;
+        padding: 36px 38px 28px;
         box-sizing: border-box;
         position: relative;
-        box-shadow: 0 42px 120px rgba(0, 0, 0, 0.65);
+        box-shadow: 0 32px 110px rgba(0, 0, 0, 0.6);
       }
 
       .monitor-surface::before {
         content: "";
         position: absolute;
-        inset: 18px 42px auto;
-        height: 20px;
+        inset: 14px 36px auto;
+        height: 18px;
         border-radius: 18px;
         background: linear-gradient(90deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
         opacity: 0.55;
@@ -61,23 +61,23 @@
 
       .monitor-camera {
         position: absolute;
-        top: 26px;
+        top: 22px;
         left: 50%;
         transform: translateX(-50%);
         width: 14px;
         height: 14px;
         border-radius: 50%;
         background: radial-gradient(circle at 30% 30%, #4b505a 0%, #181b22 55%, #07090d 100%);
-        box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.08);
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.08);
       }
 
       .monitor-screen {
         position: relative;
         width: 100%;
-        height: clamp(440px, 60vh, 720px);
-        padding: 32px;
+        height: 560px;
+        padding: 20px;
         box-sizing: border-box;
-        border-radius: 20px;
+        border-radius: 18px;
         background: radial-gradient(circle at top, #0b0d14 0%, #040507 65%, #010102 100%);
         box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.04), inset 0 0 45px rgba(0, 0, 0, 0.7);
         overflow: hidden;
@@ -87,8 +87,8 @@
       .monitor-chin {
         position: relative;
         width: 100%;
-        height: clamp(70px, 12vh, 96px);
-        margin-top: -8px;
+        height: 84px;
+        margin-top: -6px;
         background: linear-gradient(180deg, #f7f8fa 0%, #d5d9e1 52%, #bcc1cb 100%);
         border-radius: 0 0 34px 34px;
         border-top: 1px solid rgba(255, 255, 255, 0.7);
@@ -115,9 +115,9 @@
       .desktop {
         flex: 1;
         display: grid;
-        grid-template-columns: 1fr 2fr 1fr;
-        gap: 20px;
-        padding: 20px;
+        grid-template-columns: 1.1fr 2.2fr 1.1fr;
+        gap: 14px;
+        padding: 12px 16px;
         height: 100%;
         box-sizing: border-box;
       }
@@ -396,24 +396,29 @@
       }
 
       @media (max-width: 900px) {
+        .monitor {
+          width: 100%;
+        }
+
         .monitor-surface {
-          padding: 46px 40px 34px;
+          padding: 28px 24px 22px;
         }
 
         .monitor-screen {
-          padding: 26px;
-          height: clamp(400px, 60vh, 640px);
+          padding: 16px;
+          height: 520px;
         }
 
         .desktop {
-          gap: 16px;
-          padding: 16px;
+          gap: 12px;
+          padding: 10px 12px;
         }
       }
 
       @media (max-width: 640px) {
         .monitor-screen {
-          padding: 20px;
+          padding: 14px;
+          height: 480px;
         }
 
         .desktop {


### PR DESCRIPTION
## Summary
- reduce the monitor bezel thickness and page padding so the gameplay surface occupies more space
- fix the monitor screen height and adjust desktop spacing to enlarge the Schema, SQL Editor and Messenger windows
- tune responsive breakpoints to preserve the new proportions on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb3f5323c832e8cf25216847e9e8d