### PR TITLE
Add LAPD monitor frame styling around UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,21 +4,189 @@
     <meta charset="UTF-8" />
     <title>SQL Detective</title>
     <style>
-      body, html {
+      body,
+      html {
         margin: 0;
         padding: 0;
         height: 100%;
-        font-family: sans-serif;
-        background: #1e1e1e;
+        font-family: "Segoe UI", "Inter", sans-serif;
+      }
+
+      body {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(180deg, #808998 0%, #5c6473 100%);
+      }
+
+      .scene {
+        width: min(1200px, 94vw);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+        padding: 40px 24px 120px;
+        box-sizing: border-box;
+      }
+
+      .monitor {
+        width: 100%;
+        border-radius: 32px;
+        background: linear-gradient(180deg, #dee2ea 0%, #c5cad5 100%);
+        box-shadow: 0 30px 60px rgba(13, 17, 26, 0.45);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .monitor-top {
+        height: 72px;
+        position: relative;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
+        padding-bottom: 18px;
+        box-shadow: inset 0 -1px 0 rgba(126, 134, 150, 0.45);
+      }
+
+      .monitor-top .camera {
+        position: absolute;
+        top: 16px;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, #7e89a0 0%, #2c3341 100%);
+        box-shadow: 0 0 0 4px #edf0f6;
+      }
+
+      .monitor-top .camera::after {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: rgba(173, 187, 215, 0.8);
+      }
+
+      .monitor-top .speaker {
+        width: 120px;
+        height: 6px;
+        border-radius: 3px;
+        background: linear-gradient(180deg, #9ea5b5 0%, #7c8393 100%);
+        box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.6);
+      }
+
+      .monitor-screen {
+        padding: 40px 64px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 100%);
+      }
+
+      .screen-inner {
+        position: relative;
+        background: #0f1118;
+        border-radius: 26px;
+        padding: 24px;
+        height: clamp(420px, 68vh, 680px);
+        box-sizing: border-box;
+        display: flex;
+      }
+
+      .monitor-bottom {
+        padding: 32px 64px 48px;
+        background: linear-gradient(180deg, rgba(233, 236, 244, 0.85) 0%, rgba(199, 205, 216, 0.95) 100%);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        position: relative;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+      }
+
+      .monitor-bottom::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 2px;
+        background: rgba(121, 130, 146, 0.45);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 18px;
+        color: #1f2430;
+        font-size: 18px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+
+      .badge-logo {
+        width: 86px;
+        height: 86px;
+        border-radius: 50%;
+        background: radial-gradient(circle at 40% 30%, #1a1f2b 0%, #0e111b 100%);
+        border: 6px solid #f2f4f8;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 10px 22px rgba(13, 16, 24, 0.25);
+      }
+
+      .badge-logo img {
+        width: 60%;
+        height: auto;
+        display: block;
+      }
+
+      .badge-text {
+        white-space: nowrap;
+      }
+
+      .monitor-foot {
+        width: min(380px, 55vw);
+        height: 72px;
+        border-radius: 50%;
+        background: linear-gradient(180deg, #d8dce4 0%, #b9bec9 100%);
+        box-shadow: 0 24px 45px rgba(13, 17, 26, 0.4);
+        position: relative;
+        margin-top: -8px;
+      }
+
+      .monitor-foot::before {
+        content: "";
+        position: absolute;
+        inset: 12px 18%;
+        border-radius: 50%;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.85) 0%, rgba(206, 211, 220, 0.82) 100%);
+      }
+
+      .monitor-foot::after {
+        content: "";
+        position: absolute;
+        inset: 22px 28%;
+        border-radius: 50%;
+        background: rgba(164, 170, 181, 0.55);
+        filter: blur(4px);
       }
 
       .desktop {
+        flex: 1;
         display: grid;
         grid-template-columns: 1fr 2fr 1fr;
         gap: 20px;
         padding: 20px;
-        height: 100vh;
+        height: 100%;
         box-sizing: border-box;
+        min-height: 0;
+      }
+
+      .desktop > .window {
+        height: 100%;
+        min-height: 0;
       }
 
       .window {
@@ -29,6 +197,7 @@
         border-radius: 12px;
         box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
         overflow: hidden;
+        min-height: 0;
       }
 
       .title-bar {
@@ -263,11 +432,9 @@
       }
 
       .start-screen {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
         background: rgba(0, 0, 0, 0.85);
         display: flex;
         flex-direction: column;
@@ -277,7 +444,8 @@
         color: #fff;
         gap: 20px;
         padding: 20px;
-        z-index: 1000;
+        z-index: 2;
+        backdrop-filter: blur(2px);
       }
 
       .start-screen.hidden {
@@ -293,48 +461,156 @@
         font-size: 24px;
         cursor: pointer;
       }
+
+      @media (max-width: 1100px) {
+        .monitor-screen {
+          padding: 32px;
+        }
+
+        .monitor-bottom {
+          padding: 28px 32px 40px;
+        }
+
+        .screen-inner {
+          padding: 20px;
+        }
+      }
+
+      @media (max-width: 900px) {
+        .scene {
+          padding: 30px 16px 100px;
+        }
+
+        .monitor {
+          border-radius: 26px;
+        }
+
+        .monitor-top {
+          height: 64px;
+          padding-bottom: 16px;
+        }
+
+        .monitor-screen {
+          padding: 24px;
+        }
+
+        .monitor-bottom {
+          padding: 24px;
+        }
+
+        .screen-inner {
+          padding: 16px;
+          height: auto;
+          min-height: 420px;
+        }
+
+        .desktop {
+          grid-template-columns: 1fr;
+          grid-auto-rows: minmax(0, 1fr);
+          height: auto;
+        }
+
+        .desktop > .window {
+          height: auto;
+        }
+
+        .badge {
+          flex-direction: column;
+          gap: 12px;
+          text-align: center;
+        }
+
+        .badge-text {
+          white-space: normal;
+        }
+
+        .monitor-foot {
+          width: min(320px, 70vw);
+        }
+      }
+
+      @media (max-width: 600px) {
+        .monitor-screen {
+          padding: 20px 16px;
+        }
+
+        .monitor-bottom {
+          padding: 20px 16px 32px;
+        }
+
+        .screen-inner {
+          padding: 12px;
+          min-height: 360px;
+        }
+
+        .desktop {
+          gap: 16px;
+          padding: 16px;
+        }
+      }
     </style>
   </head>
   <body>
-    <div id="start-screen" class="start-screen">
-      <p id="start-text">Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти спать, вам начинают приходить тревожные сообщения</p>
-      <button id="start-button">Начать</button>
-    </div>
-    <div class="desktop">
-      <div class="window schema-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
-          </div>
-          <span class="title">Schema Master</span>
+    <div class="scene">
+      <div class="monitor">
+        <div class="monitor-top">
+          <div class="camera"></div>
+          <div class="speaker"></div>
         </div>
-        <div id="schema" class="schema-content"></div>
-      </div>
-      <div class="window editor-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
+        <div class="monitor-screen">
+          <div class="screen-inner">
+            <div id="start-screen" class="start-screen">
+              <p id="start-text">Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти спать, вам начинают приходить тревожные сообщения</p>
+              <button id="start-button">Начать</button>
+            </div>
+            <div class="desktop">
+              <div class="window schema-window">
+                <div class="title-bar">
+                  <div class="window-buttons">
+                    <span class="close"></span>
+                    <span class="minimize"></span>
+                    <span class="maximize"></span>
+                  </div>
+                  <span class="title">Schema Master</span>
+                </div>
+                <div id="schema" class="schema-content"></div>
+              </div>
+              <div class="window editor-window">
+                <div class="title-bar">
+                  <div class="window-buttons">
+                    <span class="close"></span>
+                    <span class="minimize"></span>
+                    <span class="maximize"></span>
+                  </div>
+                  <span class="title">SQL Editor</span>
+                </div>
+                <div id="editor" class="editor"></div>
+                <div id="result" class="result"></div>
+              </div>
+              <div class="window chat-window">
+                <div class="title-bar">
+                  <div class="window-buttons">
+                    <span class="close"></span>
+                    <span class="minimize"></span>
+                    <span class="maximize"></span>
+                  </div>
+                  <span class="title">Messenger</span>
+                </div>
+                <div id="chat" class="chat"></div>
+              </div>
+            </div>
           </div>
-          <span class="title">SQL Editor</span>
         </div>
-        <div id="editor" class="editor"></div>
-        <div id="result" class="result"></div>
-      </div>
-      <div class="window chat-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
+        <div class="monitor-bottom">
+          <div class="badge">
+            <div class="badge-logo">
+              <img src="/assets/lapd-logo.png" alt="Los Angeles Police Department logo" />
+            </div>
+            <span class="badge-text">Los Angeles Police Department</span>
           </div>
-          <span class="title">Messenger</span>
         </div>
-        <div id="chat" class="chat"></div>
       </div>
+      <div class="monitor-foot"></div>
     </div>
     <script type="module" src="/src/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- wrap the existing desktop layout inside a monitor-style frame that matches the provided mock
- add the LAPD badge and label to the bezel and refine the start overlay to live inside the screen
- tweak layout responsiveness so the Schema, Editor, and Messenger windows fit the framed display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef47e7298832ebdb6a63f0fb5f5ce