### PR TITLE
Add monitor frame styling to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,13 @@
     <meta charset="UTF-8" />
     <title>SQL Detective</title>
     <style>
+      /* ====== base (твои стили) ====== */
       body, html {
         margin: 0;
         padding: 0;
         height: 100%;
         font-family: sans-serif;
-        background: #1e1e1e;
+        background: #0f1320; /* чуть темнее фон, чтобы монитор выделялся */
       }
 
       .desktop {
@@ -17,8 +18,9 @@
         grid-template-columns: 1fr 2fr 1fr;
         gap: 20px;
         padding: 20px;
-        height: 100vh;
+        height: 100vh;               /* будет переопределено внутри монитора */
         box-sizing: border-box;
+        background: #1e1e1e;         /* переносим фон на «экран» */
       }
 
       .window {
@@ -58,284 +60,247 @@
         display: inline-block;
       }
 
-      .title-bar .window-buttons .close {
-        background: #ff5f57;
-      }
-
-      .title-bar .window-buttons .minimize {
-        background: #ffbd2e;
-      }
-
-      .title-bar .window-buttons .maximize {
-        background: #28c940;
-      }
-
-      .title-bar .title {
-        pointer-events: none;
-      }
+      .title-bar .window-buttons .close { background: #ff5f57; }
+      .title-bar .window-buttons .minimize { background: #ffbd2e; }
+      .title-bar .window-buttons .maximize { background: #28c940; }
+      .title-bar .title { pointer-events: none; }
 
       /* Schema window */
-      .schema-content {
-        padding: 8px;
-        overflow: auto;
-        flex: 1;
-      }
-
-      .schema-content details {
-        margin-bottom: 8px;
-      }
-
+      .schema-content { padding: 8px; overflow: auto; flex: 1; }
+      .schema-content details { margin-bottom: 8px; }
       .schema-content summary {
-        cursor: pointer;
-        list-style: none;
-        background: #e0e0e0;
-        border: 1px solid #888;
-        border-radius: 4px;
-        padding: 4px 8px;
-        display: inline-block;
+        cursor: pointer; list-style: none;
+        background: #e0e0e0; border: 1px solid #888; border-radius: 4px;
+        padding: 4px 8px; display: inline-block;
       }
-
-      .schema-content summary::after {
-        content: "\25BC";
-        font-size: 10px;
-        margin-left: 6px;
-      }
-
-      .schema-content summary::-webkit-details-marker {
-        display: none;
-      }
-
-      .schema-content ul {
-        margin: 4px 0 0 12px;
-      }
+      .schema-content summary::after { content: "\25BC"; font-size: 10px; margin-left: 6px; }
+      .schema-content summary::-webkit-details-marker { display: none; }
+      .schema-content ul { margin: 4px 0 0 12px; }
 
       /* Editor window */
       .editor {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        background: #000;
-        color: #0f0;
-        padding: 8px;
+        display: flex; flex-direction: column; flex: 1;
+        background: #000; color: #0f0; padding: 8px;
       }
-
       .editor textarea {
-        flex: 1;
-        background: #000;
-        color: #0f0;
-        border: none;
-        resize: none;
-        font-family: monospace;
-        font-size: 21px;
+        flex: 1; background: #000; color: #0f0; border: none; resize: none;
+        font-family: monospace; font-size: 21px;
       }
-
       .editor button {
-        align-self: flex-start;
-        margin-top: 4px;
-        background: #222;
-        color: #0f0;
-        border: 1px solid #0f0;
-        border-radius: 4px;
-        padding: 5px 10px;
-        font-size: 21px;
-        cursor: pointer;
+        align-self: flex-start; margin-top: 4px; background: #222; color: #0f0;
+        border: 1px solid #0f0; border-radius: 4px; padding: 5px 10px; font-size: 21px; cursor: pointer;
       }
-
-      .result {
-        flex: 1;
-        overflow: auto;
-        padding: 8px;
-        border-top: 1px solid #ccc;
-        background: #fff;
-      }
-
-      .result table {
-        border-collapse: collapse;
-        width: 100%;
-      }
-
-      .result th,
-      .result td {
-        border: 1px solid #ccc;
-        padding: 4px 8px;
-      }
-
-      .error {
-        color: red;
-        white-space: pre-wrap;
-      }
-
-      .empty {
-        color: #666;
-      }
+      .result { flex: 1; overflow: auto; padding: 8px; border-top: 1px solid #ccc; background: #fff; }
+      .result table { border-collapse: collapse; width: 100%; }
+      .result th, .result td { border: 1px solid #ccc; padding: 4px 8px; }
+      .error { color: red; white-space: pre-wrap; }
+      .empty { color: #666; }
 
       /* Chat window */
-      .chat {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        min-height: 0;
-      }
-
-      .chat .messages {
-        flex: 1;
-        overflow-y: auto;
-        padding: 8px;
-      }
-
-      .chat .msg {
-        margin-bottom: 8px;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .chat .msg.in {
-        align-items: flex-start;
-      }
-
-      .chat .msg.out {
-        align-items: flex-end;
-      }
-
-      .chat .msg .sender {
-        font-size: 12px;
-        color: #555;
-        margin-bottom: 2px;
-      }
-
-      .chat .msg .bubble {
-        max-width: 80%;
-        padding: 6px 10px;
-        border-radius: 16px;
-      }
-
-      .chat .msg.in .bubble {
-        background: #e5e5ea;
-        color: #000;
-      }
-
-      .chat .msg.smith .bubble {
-        background: #34c759;
-        color: #fff;
-      }
-
-      .chat .msg.unknown .bubble {
-        background: rgb(251, 193, 196);
-        color: #000;
-      }
-
-      .chat .msg.out .bubble {
-        background: #0b93f6;
-        color: #fff;
-      }
-
-      .chat .outgoing {
-        display: flex;
-        padding: 8px;
-        gap: 8px;
-        box-sizing: border-box;
-      }
-
+      .chat { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+      .chat .messages { flex: 1; overflow-y: auto; padding: 8px; }
+      .chat .msg { margin-bottom: 8px; display: flex; flex-direction: column; }
+      .chat .msg.in { align-items: flex-start; }
+      .chat .msg.out { align-items: flex-end; }
+      .chat .msg .sender { font-size: 12px; color: #555; margin-bottom: 2px; }
+      .chat .msg .bubble { max-width: 80%; padding: 6px 10px; border-radius: 16px; }
+      .chat .msg.in .bubble { background: #e5e5ea; color: #000; }
+      .chat .msg.smith .bubble { background: #34c759; color: #fff; }
+      .chat .msg.unknown .bubble { background: rgb(251, 193, 196); color: #000; }
+      .chat .msg.out .bubble { background: #0b93f6; color: #fff; }
+      .chat .outgoing { display: flex; padding: 8px; gap: 8px; box-sizing: border-box; }
       .chat .outgoing input {
-        flex: 1;
-        min-width: 0;
-        border: 1px solid #ccc;
-        border-radius: 16px;
-        padding: 8px 13px;
-        font-size: 14px;
+        flex: 1; min-width: 0; border: 1px solid #ccc; border-radius: 16px; padding: 8px 13px; font-size: 14px;
       }
-
       .chat .outgoing button {
-        width: 36px;
-        height: 36px;
-        flex-shrink: 0;
-        border-radius: 50%;
-        border: none;
-        background: #0b93f6;
-        color: #fff;
-        font-size: 18px;
-        cursor: pointer;
+        width: 36px; height: 36px; flex-shrink: 0; border-radius: 50%; border: none;
+        background: #0b93f6; color: #fff; font-size: 18px; cursor: pointer;
       }
-
-      .chat .outgoing button:disabled {
-        background: #9dc9f0;
-        cursor: default;
-      }
+      .chat .outgoing button:disabled { background: #9dc9f0; cursor: default; }
 
       .start-screen {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
+        /* раньше было fixed — из-за рамки делаем его локальным к экрану */
+        position: absolute;
+        inset: 0;
         background: rgba(0, 0, 0, 0.85);
+        display: flex; flex-direction: column; justify-content: center; align-items: center;
+        text-align: center; color: #fff; gap: 20px; padding: 20px; z-index: 10;
+      }
+      .start-screen.hidden { display: none; }
+      .start-screen button {
+        background: #333; color: #fff; border: none; border-radius: 8px; padding: 20px 40px; font-size: 24px; cursor: pointer;
+      }
+
+      /* ====== MONITOR FRAME ====== */
+      .monitor {
+        max-width: 1280px;
+        margin: 24px auto 56px;
+        padding: 24px;
+        border-radius: 32px;
+        background: radial-gradient(140% 100% at 50% 0%, #212531 0%, #131722 100%);
+        box-shadow:
+          0 40px 80px rgba(0,0,0,.55),
+          inset 0 1px 0 rgba(255,255,255,.06);
+      }
+
+      .monitor-bezel {
+        border-radius: 28px;
+        background: linear-gradient(180deg, #2a2f3b 0%, #1f2531 100%);
+        border: 1px solid #313745;
+        box-shadow: inset 0 2px 8px rgba(0,0,0,.6);
+        padding: 18px 18px 0; /* сверху и по бокам, внизу «борода» отдельно */
+      }
+
+      /* верхняя светлая планка с «камерой» */
+      .monitor-topbar {
+        height: 18px;
+        margin: 0 26px 10px;
+        border-radius: 10px;
+        background: #586070;
+        opacity: .4;
+        position: relative;
+      }
+
+      .monitor-camera {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%,-50%);
+        width: 10px; height: 10px; border-radius: 50%;
+        background: radial-gradient(circle at 35% 35%, #6f7686 0 35%, #1b1e25 36% 100%);
+        box-shadow: 0 0 0 2px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.08);
+      }
+
+      /* сам экран */
+      .screen {
+        position: relative;
+        border-radius: 22px;
+        background: #1e1e1e;
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.04);
+        overflow: hidden;
+        min-height: 520px;
+      }
+
+      /* «борода» (нижняя светлая панель) */
+      .monitor-chin {
+        background: #e8e9ee;
+        border-top: 1px solid #cfd2d9;
+        border-left: 1px solid #cfd2d9;
+        border-right: 1px solid #cfd2d9;
+        border-bottom: 1px solid #c2c5cc;
+        border-radius: 0 0 24px 24px;
+        padding: 22px 24px 26px;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.6);
+        text-align: center;
+      }
+
+      .monitor-badge {
+        font-size: 14px;
+        color: #2b2f38;
+        opacity: .9;
+        line-height: 1.2;
+      }
+
+      /* подставка монитора */
+      .monitor-stand {
         display: flex;
         flex-direction: column;
-        justify-content: center;
         align-items: center;
-        text-align: center;
-        color: #fff;
-        gap: 20px;
-        padding: 20px;
-        z-index: 1000;
+        gap: 10px;
+        margin-top: 18px;
+      }
+      .stand-neck {
+        width: 120px; height: 10px; border-radius: 6px;
+        background: linear-gradient(180deg, #3b4150 0%, #2b3140 100%);
+        box-shadow: inset 0 1px 0 rgba(255,255,255,.1);
+      }
+      .stand-base {
+        width: 56%;
+        height: 12px;
+        border-radius: 12px/8px;
+        background: linear-gradient(180deg, #3b4150 0%, #2b3140 100%);
+        box-shadow:
+          0 10px 18px rgba(0,0,0,.5),
+          inset 0 1px 0 rgba(255,255,255,.1);
       }
 
-      .start-screen.hidden {
-        display: none;
-      }
-
-      .start-screen button {
-        background: #333;
-        color: #fff;
-        border: none;
-        border-radius: 8px;
-        padding: 20px 40px;
-        font-size: 24px;
-        cursor: pointer;
+      /* переопределения, когда UI вставлен в «экран» */
+      .screen .desktop { height: 64vh; min-height: 480px; background: transparent; }
+      @media (max-width: 1200px) {
+        .screen .desktop { height: 70vh; }
       }
     </style>
   </head>
   <body>
-    <div id="start-screen" class="start-screen">
-      <p id="start-text">Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти спать, вам начинают приходить тревожные сообщения</p>
-      <button id="start-button">Начать</button>
+    <!-- ====== MONITOR WRAPPER ====== -->
+    <div class="monitor">
+      <div class="monitor-bezel">
+        <div class="monitor-topbar">
+          <span class="monitor-camera"></span>
+        </div>
+
+        <!-- экран монитора -->
+        <div class="screen">
+          <!-- стартовый экран теперь размещается внутри экрана -->
+          <div id="start-screen" class="start-screen">
+            <p id="start-text">
+              Вы детектив полиции и часто работаете из дома. Однажды поздно ночью, когда вы уже собирались закрыть ноутбук и пойти спать, вам начинают приходить тревожные сообщения
+            </p>
+            <button id="start-button">Начать</button>
+          </div>
+
+          <!-- твой прежний UI -->
+          <div class="desktop">
+            <div class="window schema-window">
+              <div class="title-bar">
+                <div class="window-buttons">
+                  <span class="close"></span>
+                  <span class="minimize"></span>
+                  <span class="maximize"></span>
+                </div>
+                <span class="title">Schema Master</span>
+              </div>
+              <div id="schema" class="schema-content"></div>
+            </div>
+
+            <div class="window editor-window">
+              <div class="title-bar">
+                <div class="window-buttons">
+                  <span class="close"></span>
+                  <span class="minimize"></span>
+                  <span class="maximize"></span>
+                </div>
+                <span class="title">SQL Editor</span>
+              </div>
+              <div id="editor" class="editor"></div>
+              <div id="result" class="result"></div>
+            </div>
+
+            <div class="window chat-window">
+              <div class="title-bar">
+                <div class="window-buttons">
+                  <span class="close"></span>
+                  <span class="minimize"></span>
+                  <span class="maximize"></span>
+                </div>
+                <span class="title">Messenger</span>
+              </div>
+              <div id="chat" class="chat"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="monitor-chin">
+          <div class="monitor-badge">SQL Detective</div>
+        </div>
+      </div>
+
+      <div class="monitor-stand">
+        <div class="stand-neck"></div>
+        <div class="stand-base"></div>
+      </div>
     </div>
-    <div class="desktop">
-      <div class="window schema-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
-          </div>
-          <span class="title">Schema Master</span>
-        </div>
-        <div id="schema" class="schema-content"></div>
-      </div>
-      <div class="window editor-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
-          </div>
-          <span class="title">SQL Editor</span>
-        </div>
-        <div id="editor" class="editor"></div>
-        <div id="result" class="result"></div>
-      </div>
-      <div class="window chat-window">
-        <div class="title-bar">
-          <div class="window-buttons">
-            <span class="close"></span>
-            <span class="minimize"></span>
-            <span class="maximize"></span>
-          </div>
-          <span class="title">Messenger</span>
-        </div>
-        <div id="chat" class="chat"></div>
-      </div>
-    </div>
+
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap the existing desktop UI in a stylized monitor frame with bezel, chin, and stand
- relocate the start screen overlay inside the screen and adjust desktop sizing for the new frame

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf061abf14832eae1697f0a6b8f688