### PR TITLE
Equalize spacing below desktop windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
         gap: 20px;
         padding: 20px;
         height: 100vh;               /* будет переопределено внутри монитора */
+        grid-auto-rows: 1fr;
+        align-items: stretch;
         box-sizing: border-box;
         background: #1e1e1e;         /* переносим фон на «экран» */
       }


### PR DESCRIPTION
## Summary
- stretch the grid row in the desktop layout so the window blocks fill the available height
- this evens the bottom margin with the top padding inside the monitor frame

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf10d37748832ea42dd3490d076df8