### PR TITLE
Ensure desktop windows fill monitor height

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
         gap: 20px;
         padding: 20px;
         height: 100vh;               /* будет переопределено внутри монитора */
+        grid-auto-rows: 1fr;
+        align-items: stretch;
         box-sizing: border-box;
         background: #1e1e1e;         /* переносим фон на «экран» */
       }
@@ -170,6 +172,9 @@
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.04);
         overflow: hidden;
         min-height: 500px;
+        height: 62vh;
+        display: flex;
+        flex-direction: column;
       }
 
       /* «борода» (нижняя светлая панель) */
@@ -194,9 +199,14 @@
       }
 
       /* переопределения, когда UI вставлен в «экран» */
-      .screen .desktop { height: 62vh; min-height: 460px; background: transparent; }
+      .screen .desktop {
+        flex: 1;
+        height: auto;
+        min-height: 0;
+        background: transparent;
+      }
       @media (max-width: 1200px) {
-        .screen .desktop { height: 68vh; }
+        .screen { height: 68vh; }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- make the monitor screen a flex column with a viewport-based height so the in-monitor desktop stretches vertically
- allow the desktop grid to flex to the full screen height and update the responsive override accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf10d37748832ea42dd3490d076df8