### PR TITLE
Restore monitor proportions and remove extra scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
       /* ====== MONITOR FRAME ====== */
       .monitor-bezel {
         max-width: 1280px;
-        margin: 24px auto 56px;
+        margin: 24px auto 0;
         border-radius: 28px;
         background: linear-gradient(180deg, #2a2f3b 0%, #1f2531 100%);
         border: 1px solid #313745;


### PR DESCRIPTION
## Summary
- reinstate the original screen min/relative height so the in-monitor UI keeps its full length
- trim the monitor bezel's bottom margin so the empty background no longer produces a scrollable gap

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf15308d7c832ebfcd8b3f30734736