### PR TITLE
Restore layout to monitor dimensions update

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,6 @@
         gap: 20px;
         padding: 20px;
         height: 100vh;               /* будет переопределено внутри монитора */
-        grid-auto-rows: 1fr;
-        align-items: stretch;
         box-sizing: border-box;
         background: #1e1e1e;         /* переносим фон на «экран» */
       }
@@ -136,7 +134,7 @@
       /* ====== MONITOR FRAME ====== */
       .monitor-bezel {
         max-width: 1280px;
-        margin: 24px auto 0;
+        margin: 24px auto 56px;
         border-radius: 28px;
         background: linear-gradient(180deg, #2a2f3b 0%, #1f2531 100%);
         border: 1px solid #313745;
@@ -171,10 +169,7 @@
         background: #1e1e1e;
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.04);
         overflow: hidden;
-        /* подбираем высоту так, чтобы экран и рамка в сумме не требовали вертикального скролла */
-        height: clamp(420px, 62vh, calc(100vh - 160px));
-        display: flex;
-        flex-direction: column;
+        min-height: 500px;
       }
 
       /* «борода» (нижняя светлая панель) */
@@ -199,14 +194,9 @@
       }
 
       /* переопределения, когда UI вставлен в «экран» */
-      .screen .desktop {
-        flex: 1;
-        height: auto;
-        min-height: 0;
-        background: transparent;
-      }
+      .screen .desktop { height: 62vh; min-height: 460px; background: transparent; }
       @media (max-width: 1200px) {
-        .screen { height: clamp(420px, 68vh, calc(100vh - 160px)); }
+        .screen .desktop { height: 68vh; }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- revert the landing page layout to the version from "Update UI for monitor dimensions and layout"
- remove the later adjustments to the monitor screen sizing and spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1ba626e0832ebb88fdbe9dad0385