### PR TITLE
Replace monitor chin text with LAPD logo placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,14 +188,21 @@
         margin: 0 -18px; /* растягиваем «бороду» на ширину рамки */
         padding: 22px 24px 26px;
         box-shadow: inset 0 1px 0 rgba(255,255,255,.6);
-        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       .monitor-badge {
-        font-size: 14px;
-        color: #2b2f38;
-        opacity: .9;
-        line-height: 1.2;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .monitor-logo {
+        max-height: 48px;
+        width: auto;
+        display: block;
       }
 
       /* переопределения, когда UI вставлен в «экран» */
@@ -269,7 +276,9 @@
       </div>
 
       <div class="monitor-chin">
-        <div class="monitor-badge">SQL Detective</div>
+        <div class="monitor-badge">
+          <img src="/uploads/lapd-logo.png" alt="LAPD logo" class="monitor-logo" />
+        </div>
       </div>
     </div>
 

--- a/public/uploads/README.txt
+++ b/public/uploads/README.txt
@@ -1,0 +1,1 @@
+Place LAPD logo (lapd-logo.png) in this directory.


### PR DESCRIPTION
## Summary
- display a centered LAPD logo image in the monitor chin instead of the SQL Detective text and ensure it fits within the chin
- document the new uploads directory so the lapd-logo.png file can be added manually

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfde1f1194832e8604650c0912a623