### PR TITLE
Add fade-up animation to chat messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,19 @@
       .chat .msg.out { align-items: flex-end; }
       .chat .msg .sender { font-size: 12px; color: #555; margin-bottom: 2px; }
       .chat .msg .bubble { max-width: 80%; padding: 6px 10px; border-radius: 16px; }
+      @keyframes chatMessageFadeUp {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      .chat .msg.new {
+        animation: chatMessageFadeUp 0.35s ease-out both;
+      }
       .chat .msg.in .bubble { background: #e5e5ea; color: #000; }
       .chat .msg.smith .bubble { background: #34c759; color: #fff; }
       .chat .msg.unknown .bubble { background: rgb(251, 193, 196); color: #000; }

--- a/src/state.js
+++ b/src/state.js
@@ -5,7 +5,7 @@ const state = {
 };
 
 export function addMessage(from, text) {
-  state.messages.push({ from, text });
+  state.messages.push({ from, text, rendered: false });
 }
 
 export function setOpenTables(tables) {

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -14,7 +14,7 @@ export function renderChat(container, state) {
             : m.from === 'Неизвестный'
             ? 'unknown'
             : ''
-        }">
+        } ${m.rendered ? '' : 'new'}">
           ${m.from === 'Вы' ? '' : `<div class="sender">${m.from}</div>`}
           <div class="bubble">${m.text}</div>
         </div>
@@ -27,6 +27,11 @@ export function renderChat(container, state) {
       <button disabled>&uarr;</button>
     </div>
   `;
+  state.messages.forEach((message) => {
+    if (!message.rendered) {
+      message.rendered = true;
+    }
+  });
   const btn = container.querySelector("button");
   const input = container.querySelector("input");
   btn.addEventListener("click", () => sendHandler(input.value));


### PR DESCRIPTION
## Summary
- add a fade-up animation for chat bubbles so they slide in with a short motion
- track whether a chat message has already rendered to avoid replaying the animation on re-renders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8ecbba6d0832eaf3106442c4f16a1