### PR TITLE
style: refresh schema summary buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,13 +75,59 @@
       .schema-content { padding: 8px; overflow: auto; flex: 1; }
       .schema-content details { margin-bottom: 8px; }
       .schema-content summary {
-        cursor: pointer; list-style: none;
-        background: #e0e0e0; border: 1px solid #888; border-radius: 4px;
-        padding: 4px 8px; display: inline-block;
+        cursor: pointer;
+        list-style: none;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        background: linear-gradient(135deg, #2563eb, #1d4ed8);
+        color: #f5f5f5;
+        border: 1px solid #1d4ed8;
+        border-radius: 12px;
+        padding: 10px 16px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        box-shadow: 0 10px 24px -12px rgba(37, 99, 235, 0.65);
+        transition: background 160ms ease, box-shadow 160ms ease, transform 160ms ease;
       }
-      .schema-content summary::after { content: "\25BC"; font-size: 10px; margin-left: 6px; }
+      .schema-content summary::after {
+        content: "\25BC";
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        font-size: 12px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+        color: #f5f5f5;
+        transition: transform 160ms ease, background 160ms ease;
+      }
       .schema-content summary::-webkit-details-marker { display: none; }
-      .schema-content ul { margin: 4px 0 0 12px; }
+      .schema-content summary:focus-visible {
+        outline: 2px solid rgba(37, 99, 235, 0.45);
+        outline-offset: 2px;
+      }
+      .schema-content details[open] summary {
+        background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+        box-shadow: 0 12px 28px -14px rgba(30, 64, 175, 0.7);
+        transform: translateY(-1px);
+      }
+      .schema-content details[open] summary::after {
+        transform: rotate(-180deg);
+        background: rgba(255, 255, 255, 0.2);
+      }
+      .schema-content summary:hover {
+        box-shadow: 0 12px 28px -12px rgba(37, 99, 235, 0.75);
+      }
+      .schema-content ul {
+        margin: 8px 0 0;
+        padding: 10px 14px;
+        background: #f5f5f5;
+        border-radius: 10px;
+        color: #1f2933;
+      }
 
       /* Editor window */
       .editor {


### PR DESCRIPTION
## Summary
- restyle Schema Master table toggles with a blue-forward gradient, rounded shape, and medium-depth shadowing
- add interactive hover, focus, and open states plus a refined arrow indicator for clearer affordances
- soften the revealed column list with a light gray surface to complement the refreshed buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8f275885c832e9cd9189644dbb296