### PR TITLE
style: modernize SQL result table styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,9 +177,57 @@
         align-self: flex-start; margin-top: 4px; background: #222; color: #0f0;
         border: 1px solid #0f0; border-radius: 4px; padding: 5px 10px; font-size: 21px; cursor: pointer;
       }
-      .result { flex: 1; overflow: auto; padding: 8px; border-top: 1px solid #ccc; background: #fff; }
-      .result table { border-collapse: collapse; width: 100%; }
-      .result th, .result td { border: 1px solid #ccc; padding: 4px 8px; }
+      .result {
+        flex: 1;
+        overflow: auto;
+        padding: 16px;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        background: #f3f4f6;
+      }
+      .sql-result-table {
+        width: 100%;
+        border-collapse: separate;
+        border-spacing: 0 12px;
+        color: #111827;
+      }
+      .sql-result-thead th {
+        background: #4b5563;
+        color: #f9fafb;
+        font-weight: 600;
+        text-align: left;
+        padding: 12px 16px;
+        border: none;
+        font-size: 0.9rem;
+      }
+      .sql-result-thead th:first-child {
+        border-top-left-radius: 12px;
+      }
+      .sql-result-thead th:last-child {
+        border-top-right-radius: 12px;
+      }
+      .sql-result-body tr {
+        background: #ffffff;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+        transition: box-shadow 0.2s ease, transform 0.2s ease;
+      }
+      .sql-result-body tr:hover {
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+        transform: translateY(-2px);
+      }
+      .sql-result-body td {
+        padding: 16px;
+        text-align: left;
+        border: none;
+        font-size: 0.95rem;
+      }
+      .sql-result-body tr td:first-child {
+        border-bottom-left-radius: 12px;
+        border-top-left-radius: 12px;
+      }
+      .sql-result-body tr td:last-child {
+        border-bottom-right-radius: 12px;
+        border-top-right-radius: 12px;
+      }
       .error { color: red; white-space: pre-wrap; }
       .empty { color: #666; }
 

--- a/src/ui/result.js
+++ b/src/ui/result.js
@@ -7,9 +7,16 @@ export function renderResult(container, { columns = [], rows = [], error } = {})
     container.innerHTML = `<div class="empty">Нет данных</div>`;
     return;
   }
-  const thead = `<thead><tr>${columns.map((c) => `<th>${c}</th>`).join("")}</tr></thead>`;
-  const tbody = `<tbody>${rows
-    .map((r) => `<tr>${r.map((v) => `<td>${v}</td>`).join("")}</tr>`)
+  const thead = `<thead class="sql-result-thead"><tr>${columns
+    .map((c) => `<th scope="col">${c}</th>`)
+    .join("")}</tr></thead>`;
+  const tbody = `<tbody class="sql-result-body">${rows
+    .map(
+      (r) =>
+        `<tr class="sql-result-row">${r
+          .map((v) => `<td>${v}</td>`)
+          .join("")}</tr>`
+    )
     .join("")}</tbody>`;
-  container.innerHTML = `<table>${thead}${tbody}</table>`;
+  container.innerHTML = `<table class="sql-result-table">${thead}${tbody}</table>`;
 }


### PR DESCRIPTION
## Summary
- replace the SQL result markup with semantic classes to support updated styling
- restyle the result table with a minimalist look, elevated rows, and hover feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8fa075ae4832ebeeeed3e785d85c8