### PR TITLE
Improve responsive layout for SQL Detective UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,27 +2,38 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>SQL Detective</title>
     <style>
       :root {
-        --start-screen-font-size: 1rem;
+        --start-screen-font-size: clamp(1rem, 2.4vw, 1.35rem);
       }
 
       /* ====== base (твои стили) ====== */
-      body, html {
-        margin: 0;
-        padding: 0;
+      html {
         height: 100%;
+      }
+
+      body {
+        margin: 0;
+        width: 100%;
+        min-height: 100vh;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(16px, 4vw, 48px);
+        box-sizing: border-box;
         font-family: sans-serif;
         background: #000; /* чуть темнее фон, чтобы монитор выделялся */
       }
 
       .desktop {
         display: grid;
-        grid-template-columns: 1fr 2fr 1fr;
+        grid-template-columns: minmax(220px, 1.1fr) minmax(320px, 1.8fr) minmax(220px, 1.1fr);
         gap: 20px;
         padding: 20px;
-        height: 100vh;               /* будет переопределено внутри монитора */
+        width: 100%;
         grid-auto-rows: 1fr;
         align-items: stretch;
         box-sizing: border-box;
@@ -274,13 +285,16 @@
 
       /* ====== MONITOR FRAME ====== */
       .monitor-bezel {
-        max-width: 1280px;
+        width: 100%;
+        max-width: 1200px;
         margin: 24px auto 56px;
         border-radius: 28px;
         background: linear-gradient(180deg, #2a2f3b 0%, #1f2531 100%);
         border: 1px solid #313745;
         box-shadow: inset 0 2px 8px rgba(0,0,0,.6);
         padding: 18px 18px 0; /* сверху и по бокам, внизу «борода» отдельно */
+        display: flex;
+        flex-direction: column;
       }
 
       /* верхняя светлая планка с «камерой» */
@@ -310,8 +324,9 @@
         background: #1e1e1e;
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.04);
         overflow: hidden;
-        min-height: 500px;
-        height: 62vh;
+        min-height: clamp(380px, 55vh, 640px);
+        width: 100%;
+        flex: 1 1 auto;
         display: flex;
         flex-direction: column;
       }
@@ -361,7 +376,75 @@
         background: transparent;
       }
       @media (max-width: 1200px) {
-        .screen { height: 68vh; }
+        .monitor-bezel { margin: 16px auto 40px; }
+      }
+
+      @media (max-width: 1024px) {
+        .desktop {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .editor-window {
+          grid-column: span 2;
+        }
+      }
+
+      @media (max-width: 768px) {
+        body {
+          padding: clamp(12px, 6vw, 24px);
+          align-items: flex-start;
+        }
+
+        .monitor-bezel {
+          border-radius: 24px;
+        }
+
+        .desktop {
+          grid-template-columns: 1fr;
+          gap: 16px;
+          padding: 16px;
+        }
+
+        .editor-window {
+          grid-column: auto;
+        }
+
+        .monitor-chin {
+          flex-direction: column;
+          gap: 12px;
+          padding: 18px 16px 22px;
+          text-align: center;
+        }
+
+        .monitor-badge-text {
+          white-space: normal;
+          text-align: center;
+        }
+      }
+
+      @media (max-width: 520px) {
+        .title-bar {
+          height: 24px;
+          font-size: 11px;
+        }
+
+        .window {
+          border-radius: 10px;
+        }
+
+        .desktop {
+          padding: 14px;
+        }
+
+        .start-screen {
+          padding: 16px;
+        }
+
+        .start-screen button {
+          width: 100%;
+          padding: 16px 28px;
+          font-size: 20px;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- add viewport meta tag and flexbox centering to let the interface scale with the viewport
- switch monitor bezel and screen containers to fluid widths with max-width limits and full-height backgrounds
- add responsive grid breakpoints for the desktop windows and tweak start screen controls for small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d913a209f8832e823f888be922ca3f