### PR TITLE
Add finale siren overlay and game over screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,56 @@
         font-size: var(--start-screen-font-size);
       }
 
+      .siren-overlay {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.35s ease;
+        z-index: 20;
+        background: rgba(0, 0, 0, 0);
+      }
+
+      .siren-overlay.active {
+        opacity: 1;
+        animation: policeSiren 1.6s linear infinite;
+      }
+
+      @keyframes policeSiren {
+        0%,
+        32% {
+          background: radial-gradient(circle at 15% 25%, rgba(62, 121, 255, 0.55) 0%, rgba(62, 121, 255, 0.05) 45%, rgba(0, 0, 0, 0) 70%),
+            radial-gradient(circle at 85% 80%, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0) 70%);
+        }
+        36%,
+        48% {
+          background: rgba(0, 0, 0, 0.15);
+        }
+        52%,
+        84% {
+          background: radial-gradient(circle at 85% 25%, rgba(255, 66, 79, 0.55) 0%, rgba(255, 66, 79, 0.05) 45%, rgba(0, 0, 0, 0) 70%),
+            radial-gradient(circle at 15% 75%, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0) 70%);
+        }
+        88%,
+        100% {
+          background: rgba(0, 0, 0, 0.12);
+        }
+      }
+
+      .game-over-screen {
+        z-index: 30;
+        background: rgba(0, 0, 0, 0.9);
+        gap: 16px;
+      }
+
+      .game-over-screen p {
+        margin: 0;
+        font-size: calc(var(--start-screen-font-size) * 2.4);
+        font-weight: 700;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+      }
+
       /* ====== MONITOR FRAME ====== */
       .monitor-bezel {
         max-width: 1280px;
@@ -420,6 +470,10 @@
             </div>
             <div id="chat" class="chat"></div>
           </div>
+        </div>
+        <div id="siren-overlay" class="siren-overlay"></div>
+        <div id="end-screen" class="start-screen hidden game-over-screen">
+          <p>Игра закончена</p>
         </div>
       </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,10 +14,29 @@ const chatEl = document.getElementById('chat');
 const schemaEl = document.getElementById('schema');
 const startButton = document.getElementById('start-button');
 const startText = document.getElementById('start-text');
+const sirenOverlay = document.getElementById('siren-overlay');
+const endScreen = document.getElementById('end-screen');
+let finalSequenceStarted = false;
 if (startButton && startText) {
   startText.style.width = `${startButton.offsetWidth * 3}px`;
 }
 renderChat(chatEl, state);
+
+function startFinalSequence() {
+  if (finalSequenceStarted) return;
+  finalSequenceStarted = true;
+  if (sirenOverlay) {
+    sirenOverlay.classList.add('active');
+  }
+  setTimeout(() => {
+    if (sirenOverlay) {
+      sirenOverlay.classList.remove('active');
+    }
+    if (endScreen) {
+      endScreen.classList.remove('hidden');
+    }
+  }, 10000);
+}
 
 function startFirstCycle() {
   const messages = [
@@ -56,6 +75,9 @@ onSend((text) => {
     setTimeout(() => {
       addMessage(m.from, m.text);
       renderChat(chatEl, state);
+      if (!finalSequenceStarted && m.from === 'Неизвестный' && m.text.includes('Доигрался?')) {
+        startFinalSequence();
+      }
       if (i === lastSmithIdx && stepInfo.addTables.length) {
         visibleTables.push(...stepInfo.addTables);
         setOpenTables(
@@ -78,11 +100,11 @@ renderEditor(editorEl, {
     const res = executeQuery(query);
     if (res.ok) {
       renderResult(resultEl, { columns: res.columns, rows: res.rows });
-        const check = validate(state.currentStep, res);
-        if (check.matched) {
-          const stepInfo = steps[state.currentStep];
-          setOutgoingMessage(stepInfo.outgoing);
-        }
+      const check = validate(state.currentStep, res);
+      if (check.matched) {
+        const stepInfo = steps[state.currentStep];
+        setOutgoingMessage(stepInfo.outgoing);
+      }
     } else {
       renderResult(resultEl, { error: res.error });
     }


### PR DESCRIPTION
## Summary
- add a full-screen animated siren overlay that alternates blue and red gradients for the finale
- trigger the siren effect on the last incoming message and reveal a game over splash screen after the sequence

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d98f921410832ea5d378b4089ee50e