### PR TITLE
Use BASE_URL for police siren audio

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,9 @@ const startText = document.getElementById('start-text');
 const sirenOverlay = document.getElementById('siren-overlay');
 const endScreen = document.getElementById('end-screen');
 const policeSirenAudio =
-  typeof Audio !== 'undefined' ? new Audio('/audio/police_sirene_10_sec.mp3') : null;
+  typeof Audio !== 'undefined'
+    ? new Audio(`${import.meta.env.BASE_URL}audio/police_sirene_10_sec.mp3`)
+    : null;
 if (policeSirenAudio) {
   policeSirenAudio.preload = 'auto';
 }


### PR DESCRIPTION
## Summary
- load the police siren audio asset using import.meta.env.BASE_URL to avoid hard-coded paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d999069b24832e8a4658d09a8220d9