### PR TITLE
Play notification sound for incoming messages

### DIFF
--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -1,5 +1,16 @@
 let sendHandler = () => {};
 
+const INCOMING_MESSAGE_SOUND_SRC = "/audio/ding_1,5_sec.mp3";
+
+function playIncomingMessageSound() {
+  try {
+    const audio = new Audio(INCOMING_MESSAGE_SOUND_SRC);
+    audio.play().catch(() => {});
+  } catch (err) {
+    // Игнорируем ошибки воспроизведения, чтобы не мешать интерфейсу.
+  }
+}
+
 export function renderChat(container, state) {
   container.innerHTML = `
     <div class="messages">
@@ -29,6 +40,9 @@ export function renderChat(container, state) {
   `;
   state.messages.forEach((message) => {
     if (!message.rendered) {
+      if (message.from !== "Вы") {
+        playIncomingMessageSound();
+      }
       message.rendered = true;
     }
   });


### PR DESCRIPTION
## Summary
- add a reusable helper to play the new incoming message sound effect
- trigger the notification sound whenever a newly rendered message is received from someone other than the player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2482027c832e809951ce96616b81