### PR TITLE
Fix chat incoming message sound base URL

### DIFF
--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -1,6 +1,6 @@
 let sendHandler = () => {};
 
-const INCOMING_MESSAGE_SOUND_SRC = "/audio/ding_1,5_sec.mp3";
+const INCOMING_MESSAGE_SOUND_SRC = `${import.meta.env.BASE_URL}audio/ding_1,5_sec.mp3`;
 
 function playIncomingMessageSound() {
   try {


### PR DESCRIPTION
## Summary
- update the chat incoming message sound to resolve through the configured base URL so it loads in production deployments with custom prefixes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc291e4104832e85bced1a7a2680c4