### PR TITLE
Fix Supabase column name for feedback submission

### DIFF
--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -21,7 +21,7 @@ export async function submitFeedback(rating, comment) {
         Authorization: `Bearer ${supabaseAnonKey}`,
         Prefer: 'return=minimal',
       },
-      body: JSON.stringify({ start: rating, comment }),
+      body: JSON.stringify({ stars: rating, comment }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- send feedback rating using the `stars` column to match Supabase schema

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c484579bc832e9cf8f13bc469814e)