### PR TITLE
Adjust feedback submission confirmation UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,6 +392,17 @@
         transition: transform 0.2s ease, box-shadow 0.2s ease;
       }
 
+      .rating-submit:disabled {
+        opacity: 0.88;
+        cursor: not-allowed;
+      }
+
+      .rating-submit--success {
+        background: #16a34a;
+        color: #f0fdf4;
+        box-shadow: 0 12px 28px rgba(22, 163, 74, 0.3);
+      }
+
       .rate-button:hover,
       .rating-submit:hover {
         transform: translateY(-1px);

--- a/src/main.js
+++ b/src/main.js
@@ -164,9 +164,10 @@ async function handleRatingSubmit() {
     return;
   }
 
-  setFeedbackStatus('Отправляем отзыв...', 'info');
+  setFeedbackStatus('', 'info');
   ratingSubmitButton.disabled = true;
   ratingSubmitButton.textContent = 'Отправляем...';
+  ratingSubmitButton.classList.remove('rating-submit--success');
 
   const { error } = await submitFeedback(currentRating, comment);
 
@@ -177,8 +178,8 @@ async function handleRatingSubmit() {
     return;
   }
 
-  setFeedbackStatus('Спасибо! Отзыв отправлен.', 'success');
   ratingSubmitButton.textContent = 'Отправлено';
+  ratingSubmitButton.classList.add('rating-submit--success');
 }
 
 if (ratingSubmitButton) {


### PR DESCRIPTION
## Summary
- clear status text during feedback submission and drive confirmation through the submit button state
- add success styling so the submit button turns green with the “Отправлено” label

## Testing
- npm install *(fails: 403 Forbidden fetching @vercel/analytics)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c72f44648832e82b62a3a2abf4757)